### PR TITLE
Add library.properties file

### DIFF
--- a/Arduino IDE 1.5.x/Ethernet/library.properties
+++ b/Arduino IDE 1.5.x/Ethernet/library.properties
@@ -1,0 +1,9 @@
+name=Ethernet
+version=1.0.0
+author=Soohwan Kim and Wiznet
+maintainer=Wiznet
+sentence=WIZnet Ethernet Library
+paragraph=WIZ Ethernet library is made for various Open Source Hardware Platform and support WIZnet's W5100, W5200 and W5500 chip. The Ethernet library lets you connect to the Internet or a local network.
+category=Communication
+url=https://github.com/Wiznet/WIZ_Ethernet_Library
+architectures=*


### PR DESCRIPTION
Arduino IDE 1.6.4 returns "fatal error: Ethernet.h: No such file or
directory" when a sketch that includes Ethernet.h is compiled without
the library.properties file.