### PR TITLE
Fix for ESP8266 trying to include avr/pgmspace.h

### DIFF
--- a/Arduino IDE 1.5.x/Ethernet/src/Twitter.h
+++ b/Arduino IDE 1.5.x/Ethernet/src/Twitter.h
@@ -14,7 +14,9 @@
 #define TWITTER_H
 
 #include <inttypes.h>
+#ifndef ESP8266				// Not for the ESP8266.
 #include <avr/pgmspace.h>
+#endif
 #if defined(ARDUINO) && ARDUINO > 18   // Arduino 0019 or later
 #include <SPI.h>
 #endif


### PR DESCRIPTION
Just added an "#ifndef ESP8266" around the include line, so all other Arduinos still pick it up, but the ESP8266 doesn't.